### PR TITLE
Add guide for accessing the default launcher element

### DIFF
--- a/sample/src/constants/codeSamples.ts
+++ b/sample/src/constants/codeSamples.ts
@@ -36,7 +36,13 @@ messenger.onLoad(() => {
 
 function closeAgent() {
   messenger.close();
-}`,
+}
+
+// If you want to hide the default launcher button:
+// 1. Initialize with useShadowDOM: false to access elements
+// const messenger = await loadMessenger({ useShadowDOM: false });
+// 2. Then hide the launcher
+// document.getElementById('sb-agent-launcher').style.display = 'none';`,
 
   messenger_locale: `// language and country code settings for the messenger
 messenger.initialize({


### PR DESCRIPTION

This PR adds documentation about how to access and hide the default launcher button in the Sendbird Messenger.

<img width="600" alt="Screenshot 2025-04-30 at 5 17 35 PM" src="https://github.com/user-attachments/assets/d1c6972a-c728-434d-b2d1-73bbdc8b3df4" />


## Changes
- Added comments in the controls section explaining that `useShadowDOM: false` is required to access DOM elements
- Added example code showing how to hide the default launcher button with element id  `sb-agent-launcher`
