### PR TITLE
Remove deauthenticate and clear session functionality

### DIFF
--- a/js/live-example/src/components/sections/reactExample/AdvancedFeatures.tsx
+++ b/js/live-example/src/components/sections/reactExample/AdvancedFeatures.tsx
@@ -224,21 +224,6 @@ export const AdvancedFeatures = () => {
           </div>
         </Section>
 
-        <Section
-          title="Cleanup"
-          description="Methods for cleaning up messenger resources and forcing component remount."
-        >
-          <CodeEditor value={REACT_CODE_SAMPLES.cleanup} language="tsx" />
-          <Button
-            onClick={() =>
-              updateAppConfig({
-                messengerKey: appConfig.messengerKey + 1,
-              })
-            }
-          >
-            Reset Messenger
-          </Button>
-        </Section>
       </div>
     </div>
   );

--- a/js/live-example/src/constants/codeSamples.ts
+++ b/js/live-example/src/constants/codeSamples.ts
@@ -322,25 +322,6 @@ function App() {
   }}
 />`,
 
-  cleanup: `// Component cleanup is handled automatically by React
-// when the component unmounts, but you can also
-// control the messenger state manually:
-
-function App() {
-  const [messengerKey, setMessengerKey] = useState(0);
-
-  const resetMessenger = () => {
-    setMessengerKey(prev => prev + 1); // Force remount
-  };
-
-  return (
-    <FixedMessenger
-      key={messengerKey}
-      appId="YOUR_APP_ID"
-      aiAgentId="YOUR_AI_AGENT_ID"
-    />
-  );
-}`,
 
   messageLayoutCustomization: `import { AgentProviderContainer, Conversation, IncomingMessageLayout } from '@sendbird/ai-agent-messenger-react';
 import { useState } from 'react';

--- a/js/react/README.md
+++ b/js/react/README.md
@@ -17,7 +17,6 @@ The **Sendbird AI Agent Messenger React** allows seamless integration of chatbot
     - [Manage user sessions](#manage-user-sessions)
   - [Advanced Features](#advanced-features)
     - [Display messenger without launcher button](#display-messenger-without-launcher-button)
-    - [Deauthenticate and clear session](#deauthenticate-and-clear-session)
     - [Passing context object to Agent](#passing-context-object-to-agent)
     - [Localization and Language Support](#localization-and-language-support)
 
@@ -241,28 +240,6 @@ function App() {
         <Conversation />
       </AgentProviderContainer>
     </div>
-  );
-}
-```
-
-### Deauthenticate and clear session
-
-Component cleanup is handled automatically by React when the component unmounts, but you can also control the messenger state manually:
-
-```tsx
-function App() {
-  const [messengerKey, setMessengerKey] = useState(0);
-
-  const resetMessenger = () => {
-    setMessengerKey(prev => prev + 1); // Force remount
-  };
-
-  return (
-    <FixedMessenger
-      key={messengerKey}
-      appId="YOUR_APP_ID"
-      aiAgentId="YOUR_AI_AGENT_ID"
-    />
   );
 }
 ```


### PR DESCRIPTION
## Summary
- Remove "Deauthenticate and clear session" section from React README
- Remove cleanup section from React live example components  
- Remove associated code samples for session clearing functionality

## Reason
This functionality is not yet implemented in the React SDK and the documentation was incorrect.

## Test plan
- [x] Verify README no longer contains deauthenticate section
- [x] Verify live example no longer shows cleanup functionality
- [x] Verify all references to cleanup code samples are removed